### PR TITLE
fix: allow export all as identifier syntax

### DIFF
--- a/src/decl.rs
+++ b/src/decl.rs
@@ -142,7 +142,10 @@ pub enum ModExport<'a> {
     /// ```js
     /// export * from 'mod';
     /// ```
-    All(Lit<'a>),
+    All {
+        alias: Option<Ident<'a>>,
+        name: Lit<'a>,
+    },
 }
 
 // pub struct NamedExportDecl<'a> {

--- a/src/spanned/decl.rs
+++ b/src/spanned/decl.rs
@@ -387,6 +387,7 @@ pub enum ModExportSpecifier<'a> {
     /// ```
     All {
         star: Slice<'a>,
+        alias: Option<Alias<'a>>,
         keyword: Slice<'a>,
         name: Lit<'a>,
     },
@@ -415,9 +416,13 @@ impl<'a> From<ModExportSpecifier<'a>> for crate::decl::ModExport<'a> {
             ModExportSpecifier::Named(inner) => Self::Named(inner.into()),
             ModExportSpecifier::All {
                 star: _,
+                alias,
                 keyword: _,
                 name,
-            } => Self::All(name.into()),
+            } => Self::All {
+                alias: alias.map(|a| a.ident.into()),
+                name: name.into()
+            },
         }
     }
 }


### PR DESCRIPTION
This is required to support the `export * as A from 'module'` syntax