### PR TITLE
Fix/import all as

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resast"
-version = "0.6.0-alpha.2"
+version = "0.6.0-alpha.3"
 authors = ["rfm <r.f.masen@gmail.com>"]
 edition = "2018"
 description = "Rusty-ECMAScript Abstract Syntax Tree"

--- a/src/spanned/decl.rs
+++ b/src/spanned/decl.rs
@@ -255,7 +255,7 @@ impl<T> Node for DefaultImportSpec<T> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct NamespaceImportSpec<T> {
     pub star: Asterisk,
-    pub keyword: From,
+    pub keyword: As,
     pub ident: Ident<T>,
 }
 


### PR DESCRIPTION
fix a bug that was incorrectly identifying `import * as i from 'module` as `import * from i`