### PR TITLE
new operators, first try at optional chain

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -89,6 +89,7 @@ pub enum Expr<T> {
     Update(UpdateExpr<T>),
     /// yield a value from inside of a generator function
     Yield(YieldExpr<T>),
+    OptionalChain(Box<Expr<T>>),
 }
 
 impl<T> IntoAllocated for Expr<T>
@@ -134,6 +135,7 @@ where
             Expr::Unary(inner) => Expr::Unary(inner.into_allocated()),
             Expr::Update(inner) => Expr::Update(inner.into_allocated()),
             Expr::Yield(inner) => Expr::Yield(inner.into_allocated()),
+            Expr::OptionalChain(inner) => Expr::OptionalChain(inner.into_allocated()),
         }
     }
 }
@@ -602,6 +604,7 @@ where
         }
     }
 }
+
 /// A Template literal preceded by a function identifier
 /// see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates) for more details
 #[derive(PartialEq, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,9 @@ pub enum AssignOp {
     XOrEqual,
     AndEqual,
     PowerOfEqual,
+    DoubleAmpersandEqual,
+    DoublePipeEqual,
+    DoubleQuestionmarkEqual,
 }
 
 /// The available logical operators
@@ -375,6 +378,7 @@ pub enum AssignOp {
 pub enum LogicalOp {
     Or,
     And,
+    NullishCoalescing,
 }
 
 /// The available operations for `Binary` Exprs

--- a/src/spanned/convert.rs
+++ b/src/spanned/convert.rs
@@ -219,6 +219,7 @@ mod expr {
                 Expr::Update(inner) => Self::Update(inner.into()),
                 Expr::Yield(inner) => Self::Yield(inner.into()),
                 Expr::Wrapped(inner) => inner.expr.into(),
+                Expr::OptionalChain(inner) => Self::OptionalChain(Box::new((*inner.expr).into())),
             }
         }
     }
@@ -692,6 +693,9 @@ impl From<AssignOp> for crate::AssignOp {
             AssignOp::XOrEqual(_) => Self::XOrEqual,
             AssignOp::AndEqual(_) => Self::AndEqual,
             AssignOp::PowerOfEqual(_) => Self::PowerOfEqual,
+            AssignOp::DoubleAmpersandEqual(_) => Self::DoubleAmpersandEqual,
+            AssignOp::DoublePipeEqual(_) => Self::DoublePipeEqual,
+            AssignOp::DoubleQuestionmarkEqual(_) => Self::DoubleQuestionmarkEqual,
         }
     }
 }
@@ -701,6 +705,7 @@ impl From<LogicalOp> for crate::LogicalOp {
         match other {
             LogicalOp::Or(_) => Self::Or,
             LogicalOp::And(_) => Self::And,
+            LogicalOp::NullishCoalescing(_) => Self::NullishCoalescing,
         }
     }
 }

--- a/src/spanned/tokens.rs
+++ b/src/spanned/tokens.rs
@@ -162,6 +162,7 @@ define_token!(CloseBracket, "]");
 define_token!(Colon, ":");
 define_token!(Comma, ",");
 define_token!(DoubleAmpersand, "&&");
+define_token!(DoubleAmpersandEqual, "&&=");
 define_token!(DoubleAsterisk, "**");
 define_token!(DoubleAsteriskEqual, "**=");
 define_token!(DoubleEqual, "==");
@@ -171,6 +172,9 @@ define_token!(DoubleGreaterThanEqual, ">>=");
 define_token!(DoubleLessThan, "<<");
 define_token!(DoubleLessThanEqual, "<<=");
 define_token!(DoublePipe, "||");
+define_token!(DoublePipeEqual, "||=");
+define_token!(DoubleQuestionmark, "??");
+define_token!(DoubleQuestionmarkEqual, "??=");
 define_token!(DoubleQuote, "\"");
 define_token!(Ellipsis, "...");
 define_token!(Equal, "=");
@@ -194,6 +198,7 @@ define_token!(PipeEqual, "|=");
 define_token!(Plus, "+");
 define_token!(PlusEqual, "+=");
 define_token!(QuestionMark, "?");
+define_token!(QuestionMarkDot, "?.");
 define_token!(Semicolon, ";");
 define_token!(SingleQuote, "'");
 define_token!(Tilde, "~");
@@ -282,6 +287,9 @@ pub enum AssignOp {
     XOrEqual(CaretEqual),
     AndEqual(AmpersandEqual),
     PowerOfEqual(DoubleAsteriskEqual),
+    DoubleAmpersandEqual(DoubleAmpersandEqual),
+    DoublePipeEqual(DoublePipeEqual),
+    DoubleQuestionmarkEqual(DoubleQuestionmarkEqual),
 }
 
 impl Node for AssignOp {
@@ -300,6 +308,9 @@ impl Node for AssignOp {
             AssignOp::XOrEqual(tok) => tok.loc(),
             AssignOp::AndEqual(tok) => tok.loc(),
             AssignOp::PowerOfEqual(tok) => tok.loc(),
+            AssignOp::DoubleAmpersandEqual(tok) => tok.loc(),
+            AssignOp::DoublePipeEqual(tok) => tok.loc(),
+            AssignOp::DoubleQuestionmarkEqual(tok) => tok.loc(),
         }
     }
 }
@@ -310,6 +321,7 @@ impl Node for AssignOp {
 pub enum LogicalOp {
     Or(DoublePipe),
     And(DoubleAmpersand),
+    NullishCoalescing(DoubleQuestionmark),
 }
 
 impl Node for LogicalOp {
@@ -317,6 +329,7 @@ impl Node for LogicalOp {
         match self {
             LogicalOp::Or(tok) => tok.loc(),
             LogicalOp::And(tok) => tok.loc(),
+            LogicalOp::NullishCoalescing(tok) => tok.loc(),
         }
     }
 }


### PR DESCRIPTION
This PR adds support for the `&&=`, `||=`, `??` and `??=` with a first try at the `.?` (optional chain) expression